### PR TITLE
docs: correct install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ To bring KinoExcalidraw to Livebook all you need to do is `Mix.install/2`:
 
 ```elixir
 Mix.install([
-  {:kino_excalidraw, "< 1.0.0"}
+  {:kino_excalidraw, "~> 1.0.0"}
 ])
 ```


### PR DESCRIPTION
I don't believe any version constraint can start with `<`. The most common constraint is `~>`.